### PR TITLE
Fix Windows Vulkan build: link dxgi for the DXGI presenter regardless of backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,39 @@ python launcher/launcher.py
 The build stages `rexruntime*.dll` and `TracyClient*.dll` next to `simpsons.exe`
 automatically — Windows has no `LD_LIBRARY_PATH`, so DLLs live beside the exe.
 
+### Building with Vulkan on Windows
+
+Windows defaults to the **D3D12** backend, but the **Vulkan** backend also builds and
+runs on Windows (it is the default on Linux). This is useful if you want the fragment
+shader interlock render path, or if you are hitting a D3D12-only issue — for example,
+FMV playback (`.vp6`) currently shows a black screen on the host render target path
+(D3D12, and Vulkan with `render_target_path_vulkan=""`), while it plays fine on the
+Vulkan interlock path.
+
+Prerequisites are the same as the D3D12 build above. Configure a separate build
+directory so the SDK output does not clobber the D3D12 one:
+
+```powershell
+cmake -S simpsons -B simpsons/out/build/win-vk -G Ninja `
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ `
+      "-DCMAKE_CXX_FLAGS=-march=x86-64-v3" `
+      -DREXGLUE_USE_D3D12=OFF -DREXGLUE_USE_VULKAN=ON `
+      -DREXSDK_DIR="$PWD/tools/rexglue-sdk"
+cmake --build simpsons/out/build/win-vk --target simpsons
+```
+
+Notes:
+
+- The Vulkan backend links `dxgi` on Windows because the presenter (`rexui`) uses
+  DXGI for the swapchain regardless of the graphics backend (this was only linked in
+  the D3D12 branch).
+- The SDK output directory (`tools/rexglue-sdk/out/win-amd64`) is shared between the
+  D3D12 and Vulkan builds — building the Vulkan variant overwrites
+  `rexruntimerd.dll` there, so back it up before switching back to D3D12.
+- Use a `RelWithDebInfo`/`Release` build type: without `-DNDEBUG`, the render path
+  assertions (`GetPath() == Path::kHostRenderTargets`) fire on the interlock path.
+
 ## Legal & disclaimers
 
 *The Simpsons Game* © 2007 Electronic Arts / Fox. This is an unaffiliated, non-commercial

--- a/tools/rexglue-sdk/src/graphics/CMakeLists.txt
+++ b/tools/rexglue-sdk/src/graphics/CMakeLists.txt
@@ -130,6 +130,11 @@ if(REXGLUE_USE_VULKAN)
         glslang::SPIRV
         GPUOpen::VulkanMemoryAllocator
     )
+    # The presenter (rexui) uses DXGI for the swapchain/display on Windows
+    # regardless of the graphics backend.
+    if(WIN32)
+        target_link_libraries(rexgraphics PUBLIC dxgi)
+    endif()
     target_link_libraries(rexgraphics PRIVATE
         glslang
         MachineIndependent


### PR DESCRIPTION
### Title
Fix Windows Vulkan build: link dxgi for the DXGI presenter regardless of backend

### Problem
On Windows, building with `-DREXGLUE_USE_D3D12=OFF -DREXGLUE_USE_VULKAN=ON` fails at link time:

```
lld-link: error: undefined symbol: CreateDXGIFactory1
>>> referenced by rexglue-sdk/src/ui/presenter.cpp:1462
```

The presenter (`rexui`) uses DXGI for the swapchain on Windows **regardless of the graphics backend**, but `dxgi` was only linked in the D3D12 branch of `src/graphics/CMakeLists.txt`.

### Change
```cmake
if(REXGLUE_USE_VULKAN)
    target_link_libraries(rexgraphics PUBLIC volk::volk glslang::SPIRV GPUOpen::VulkanMemoryAllocator)
    if(WIN32)
        target_link_libraries(rexgraphics PUBLIC dxgi)   # ← added
    endif()
    ...
endif()
```

### Also in this PR
README section **"Building with Vulkan on Windows"** — configure command, plus notes:
- the SDK output dir (`tools/rexglue-sdk/out/win-amd64`) is shared between the D3D12 and Vulkan builds, so the Vulkan build overwrites `rexruntimerd.dll` there;
- a `RelWithDebInfo`/`Release` build type is required (without `-DNDEBUG`, the render-path assertions fire on the interlock path).

### Testing
Built and ran on Windows 11 / AMD Radeon RX 6700: Vulkan instance 1.4.341, FMV playback works, 90-minute session stable, clean shutdown.

### Files changed
- `tools/rexglue-sdk/src/graphics/CMakeLists.txt` (+5)
- `README.md` (+33)
