### PR TITLE
launcher: add vulkan_device setting to launcher UI

### DIFF
--- a/launcher/launcher.py
+++ b/launcher/launcher.py
@@ -255,6 +255,7 @@ SETTINGS_SCHEMA = {
     # graphics backend: "" = automatic (Vulkan first, D3D12 fallback on
     # Windows), "vulkan" or "d3d12" to force one. Chosen at startup.
     "gpu": ("str", "", True),
+    "vulkan_device": ("str", "", True),
     # audio
     "audio_mute": ("bool", False, False),
     "audio_maxqframes": ("int", 32, True),

--- a/launcher/ui/index.html
+++ b/launcher/ui/index.html
@@ -304,6 +304,15 @@
           <div class="hint">Vulkan plays the intro videos and matches console colors. Pick Direct3D 12 only if Vulkan fails on your GPU. Restart needed.</div>
         </div>
         <div class="field">
+          <label>Vulkan Device (Multi-GPU / Laptop)</label>
+          <select id="s-vulkan_device">
+            <option value="">Automatic (Recommended)</option>
+            <option value="0">Device 0</option>
+            <option value="1">Device 1</option>
+          </select>
+          <div class="hint">Select the GPU device index to use when GPU backend is set to Vulkan. Leave on Automatic if unsure.</div>
+        </div>
+        <div class="field">
           <label class="switch"><input type="checkbox" id="s-vsync"> VSync</label>
         </div>
         <div class="field">
@@ -1053,6 +1062,7 @@ async function loadSettings(){
   $("#s-fullscreen").value = String(v.fullscreen);
   $("#s-resolution").value = v.resolution || "";
   $("#s-gpu").value = v.gpu || "";
+  $("#s-vulkan_device").value = v.vulkan_device || "";
   $("#s-vsync").checked = v.vsync;
   $("#s-present_letterbox").checked = v.present_letterbox;
   $("#s-resolution_scale").value = String(v.resolution_scale);
@@ -1075,6 +1085,7 @@ $("#savebtn").onclick = async () => {
     fullscreen: $("#s-fullscreen").value === "true",
     resolution: $("#s-resolution").value,
     gpu: $("#s-gpu").value,
+    vulkan_device: $("#s-vulkan_device").value,
     vsync: $("#s-vsync").checked,
     present_letterbox: $("#s-present_letterbox").checked,
     resolution_scale: Number($("#s-resolution_scale").value),


### PR DESCRIPTION
Adds an option to select the Vulkan device index in the launcher UI to support multi-GPU and laptop configurations.

**Testing**
Tested on CachyOS (Arch Linux) with an RTX 3050 Ti Laptop (dGPU) + AMD Radeon Vega 7 (iGPU). Verified that Automatic uses default behavior and specifying a device index correctly overrides the Vulkan device.